### PR TITLE
refactor: migrate project from NASA to CA DEQ (CalEPA) document Q&A s…

### DIFF
--- a/MDS.md
+++ b/MDS.md
@@ -1,0 +1,54 @@
+# Module Design Specification (MDS)
+
+## 1. Module: `common/cadeq_search.py`
+
+- **Purpose:** Implements the `CADEQDocumentSearch` class for vector search and RAG over CA DEQ/CalEPA studies.
+- **Key Functions:**
+  - `CADEQDocumentSearch`: Handles vector DB connection, semantic search, and LLM-based answer generation.
+  - `get_cadeq_search_tool`: Returns a LangChain tool for agent integration.
+  - `get_cadeq_db_info`: Returns metadata about the vector database.
+
+## 2. Module: `common/agent_factory.py`
+
+- **Purpose:** Implements the `AgentFactory` for creating agents with CA DEQ and optional MCP tools.
+- **Key Functions:**
+  - `AgentFactory`: Handles agent creation, tool integration, and prompt generation.
+  - `create_cadeq_agent`: Factory function for main application.
+
+## 3. Module: `fetch_cadeq_data.py`
+
+- **Purpose:** Downloads 10 CA DEQ/CalEPA studies and reports as PDFs for ingestion.
+- **Key Functions:**
+  - `download_cadeq_documents`: Downloads and saves all source PDFs to the `data/` directory.
+
+## 4. Module: `ingest.py`
+
+- **Purpose:** Ingests all CA DEQ PDFs, splits into chunks, and builds Chroma vector DB.
+- **Key Functions:**
+  - Loads all PDFs from `data/`
+  - Splits documents into chunks
+  - Embeds and stores in Chroma DB
+
+## 5. Module: `main.py`
+
+- **Purpose:** User interface for Q&A over CA DEQ documents.
+- **Key Functions:**
+  - Loads configuration and agent
+  - Handles user input and displays answers
+
+## 6. Module: `debug_embeddings.py` and `test_retrieval.py`
+
+- **Purpose:** Test and debug scripts for embeddings and retrieval, using CA DEQ/environmental queries.
+- **Key Functions:**
+  - Test embedding pipeline and vector DB
+  - Run sample queries for retrieval validation
+
+## 7. Data and Document Flow
+
+- Documents are downloaded via `fetch_cadeq_data.py` and stored in `data/`.
+- `ingest.py` processes PDFs, splits, embeds, and builds the Chroma DB.
+- `CADEQDocumentSearch` in `common/cadeq_search.py` provides semantic search and LLM-based answers.
+- The agent (from `common/agent_factory.py`) orchestrates tool use and response generation.
+- `main.py` provides the CLI for user interaction.
+
+--- 

--- a/SDS.md
+++ b/SDS.md
@@ -1,0 +1,66 @@
+# Software Design Specification (SDS)
+
+## 1. Overview
+
+The CA DEQ Document Q&A System is an intelligent, modular application that enables executive-level question answering over California Department of Environmental Quality (CalEPA) studies and reports. It leverages LangChain, OpenAI LLMs, and Chroma vector database, with optional integration of Model Context Protocol (MCP) for external tool access.
+
+## 2. System Architecture
+
+### 2.1 Layered Architecture
+
+The system follows a clean, 5-layer modular architecture:
+
+1. **Configuration Layer** (`common/config.py`): Loads and validates environment variables and settings.
+2. **Data Layer** (`common/cadeq_search.py`): Manages vector database and document retrieval for CA DEQ studies.
+3. **Integration Layer** (`common/mcp_client.py`): Handles optional MCP server connections for external tools.
+4. **Agent Layer** (`common/agent_factory.py`): Creates and configures AI agents with CA DEQ and optional MCP tools.
+5. **Presentation Layer** (`main.py`): Provides user interface and interaction.
+
+### 2.2 Data Flow
+
+- User submits a question via the CLI (`main.py`).
+- The agent (from `common/agent_factory.py`) receives the query and determines which tools to use.
+- The CA DEQ document search tool (`common/cadeq_search.py`) performs semantic search and retrieval over embedded CA DEQ/CalEPA studies.
+- The agent synthesizes an executive-level answer using the retrieved context and the LLM.
+- The answer is returned to the user.
+
+## 3. Key Features
+
+- PDF ingestion and vectorization of CA DEQ/CalEPA studies
+- Semantic search and retrieval
+- Executive summary generation
+- Optional filesystem tool integration via MCP
+- Modular, clean 5-layer architecture
+
+## 4. External Dependencies
+
+- LangChain
+- OpenAI API
+- Chroma vector database
+- Requests, dotenv, etc.
+
+## 5. Document Sources
+
+The system uses the following CA DEQ/CalEPA studies and reports as its knowledge base:
+
+- 2014 Annual Report on the Air Resources Board's Fine Particulate Matter Monitoring Program
+- Indicators of Climate Change in California (2013)
+- California Water Action Plan
+- 2019 CalEPA Enforcement Report
+- Environmental Justice Program Update (2016)
+- Improving Public and Worker Safety at Oil Refineries (2014)
+- Draft California Communities Environmental Health Screening Tool Report (CalEnviroScreen 2.0)
+- 2013 Annual Report on the Air Resources Board's Fine Particulate Matter Monitoring Program
+- A Report To The California Legislature on the Potential Health and Environmental Impacts of Leaf Blowers
+- Source apportionment of fine and ultrafine particles in California
+
+## 6. Security and Privacy
+
+- All documents are public CA DEQ/CalEPA reports.
+- No user data is stored.
+
+## 7. Future Improvements
+
+- Add support for additional CA DEQ/CalEPA document types.
+- Enhance prompt engineering for more nuanced executive summaries.
+- Integrate with more advanced retrieval and summarization models as they become available. 

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,18 +1,18 @@
 # =============================================================================
 # Common Utilities Package
 # =============================================================================
-# This package contains shared utilities used across the NASA Q&A system.
+# This package contains shared utilities used across the CA DEQ Q&A system.
 # =============================================================================
 
 """
-Common utilities package for NASA Document Q&A System
-Provides reusable components for MCP integration, NASA search, and agent configuration
+Common utilities package for CA DEQ Document Q&A System
+Provides reusable components for MCP integration, CA DEQ search, and agent configuration
 """
 
 from .thinking_spinner import ThinkingSpinner
 from .mcp_client import get_mcp_tools, MCPClient
-from .nasa_search import get_nasa_search_tool, get_nasa_db_info, NASADocumentSearch
-from .agent_factory import create_nasa_agent, AgentFactory
+from .cadeq_search import get_cadeq_search_tool, get_cadeq_db_info, CADEQDocumentSearch
+from .agent_factory import create_cadeq_agent, AgentFactory
 from .config import get_config, load_environment, AppConfig
 
 __all__ = [
@@ -23,13 +23,13 @@ __all__ = [
     'get_mcp_tools',
     'MCPClient',
     
-    # NASA document search
-    'get_nasa_search_tool',
-    'get_nasa_db_info', 
-    'NASADocumentSearch',
+    # CA DEQ document search
+    'get_cadeq_search_tool',
+    'get_cadeq_db_info', 
+    'CADEQDocumentSearch',
     
     # Agent creation
-    'create_nasa_agent',
+    'create_cadeq_agent',
     'AgentFactory',
     
     # Configuration

--- a/common/agent_factory.py
+++ b/common/agent_factory.py
@@ -29,7 +29,7 @@ from typing import List
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 from .mcp_client import get_mcp_tools
-from .nasa_search import get_nasa_search_tool
+from .cadeq_search import get_cadeq_search_tool
 
 
 class AgentFactory:
@@ -106,17 +106,17 @@ class AgentFactory:
         - Termination: Agent provides final answer when task complete
         """
         # TOOL DISCOVERY PHASE
-        # Start with core NASA document search capability
-        tools = [get_nasa_search_tool()]
+        # Start with core CA DEQ document search capability
+        tools = [get_cadeq_search_tool()]
         
         # Add MCP tools if requested and available
         mcp_tools = get_mcp_tools() if include_mcp else []
         
         if mcp_tools:
             tools.extend(mcp_tools)
-            print(f"🔧 Agent created with {len(mcp_tools)} MCP tools + NASA search")
+            print(f"🔧 Agent created with {len(mcp_tools)} MCP tools + CA DEQ search")
         else:
-            print("🔧 Agent created with NASA search only")
+            print("🔧 Agent created with CA DEQ search only")
         
         # MODEL CONFIGURATION PHASE
         # Configure LLM with specified parameters
@@ -170,53 +170,53 @@ class AgentFactory:
         - Concise, high-impact communication style
         """
         if has_mcp_tools:
-            return """You are a helpful AI assistant with access to NASA documents and filesystem tools.
+            return """You are a helpful AI assistant with access to CA DEQ (CalEPA) documents and filesystem tools.
 
 TOOLS AVAILABLE:
-• nasa_document_search: For questions about NASA missions, engineering, policies, and space exploration
+• cadeq_document_search: For questions about California environmental quality, air, water, policy, and related topics
 • list_directory: List contents of a directory (use with specific path like "." for current directory)
 • read_file: Read contents of text files
 • search_files: Search for files by pattern in a directory
 • get_file_info: Get detailed information about files
 
 USAGE GUIDELINES:
-- For NASA/space questions: Use nasa_document_search
+- For CA DEQ/environmental questions: Use cadeq_document_search
 - For filesystem operations: Use the MCP tools explicitly
 - Be proactive in using the appropriate tools
 - Always provide helpful, detailed responses
 
 Examples:
-- "What are NASA's risk strategies?" → Use nasa_document_search
+- "What are California's air quality risk strategies?" → Use cadeq_document_search
 - "List current directory" → Use list_directory with path "."
 - "Read README file" → Use read_file with file path"""
         else:
-            return """You are a helpful AI assistant with access to NASA documents.
+            return """You are a helpful AI assistant with access to CA DEQ (CalEPA) documents.
 
-Use the nasa_document_search tool to answer questions about NASA missions, engineering, policies, and space exploration.
-Always provide executive-level, detailed responses based on the NASA documentation."""
+Use the cadeq_document_search tool to answer questions about California environmental quality, air, water, policy, and related topics.
+Always provide executive-level, detailed responses based on the CA DEQ documentation."""
 
 
-def create_nasa_agent(include_mcp: bool = True, model: str = "gpt-4.1"):
+def create_cadeq_agent(include_mcp: bool = True, model: str = "gpt-4.1"):
     """
-    Convenience function for creating NASA Q&A agents.
+    Convenience function for creating CA DEQ Q&A agents.
     
     Args:
         include_mcp: Whether to include MCP filesystem tools
         model: OpenAI model name for the agent
         
     Returns:
-        Configured agent ready for NASA document Q&A
+        Configured agent ready for CA DEQ document Q&A
         
     CONVENIENCE FUNCTION BENEFITS:
     - Simplified interface for common use cases
-    - Sensible defaults for NASA Q&A scenarios
+    - Sensible defaults for CA DEQ Q&A scenarios
     - Consistent agent configuration across application
     - Reduced boilerplate code in application entry points
     
     USAGE PATTERNS:
     - Development: include_mcp=True for full feature testing
     - Production: include_mcp based on deployment environment
-    - Testing: include_mcp=False for isolated NASA search testing
+    - Testing: include_mcp=False for isolated CA DEQ search testing
     - Custom Models: model parameter for different AI capabilities
     
     This function is the primary interface for agent creation in most

--- a/debug_embeddings.py
+++ b/debug_embeddings.py
@@ -53,10 +53,10 @@ def test_vector_database():
         
         # Test retrieval with different queries
         test_queries = [
-            "NASA risk management",
-            "technical risk mitigation", 
-            "systems engineering",
-            "Artemis mission"
+            "CA DEQ risk management",
+            "air quality monitoring", 
+            "environmental justice",
+            "California water action"
         ]
         
         for query in test_queries:

--- a/fetch_cadeq_data.py
+++ b/fetch_cadeq_data.py
@@ -1,0 +1,97 @@
+"""
+CA DEQ Document Downloader
+
+This module downloads official California Department of Environmental Quality (CA DEQ, CalEPA) documents from public sources for use in the
+CA DEQ Document Q&A System. It retrieves PDF studies and reports from CalEPA and related agencies.
+
+The downloaded documents are stored in the ./data directory and serve as the
+source material for the document ingestion pipeline (ingest.py).
+
+Dependencies:
+    - requests: For HTTP downloads
+    - os: For directory creation
+
+Usage:
+    python fetch_cadeq_data.py
+
+    Or via Makefile:
+    make fetch-data
+
+Documents Downloaded:
+    - 10 CA DEQ/CalEPA studies and reports (see URLS below)
+
+Author: CA DEQ Q&A System
+License: MIT
+"""
+from typing import Dict
+import os
+import requests
+
+# =============================================================================
+# CA DEQ DOCUMENT SOURCES
+# =============================================================================
+# Official CA DEQ/CalEPA PDF documents with their download URLs
+
+URLS: Dict[str, str] = {
+    "2014_arb_pm_report.pdf": "https://ww2.arb.ca.gov/sites/default/files/classic/research/apr/reports/l3007.pdf",
+    "indicators_climate_change_2013.pdf": "https://ww2.arb.ca.gov/sites/default/files/classic/cc/inventory/pubs/reports/indicators/indicators-2013.pdf",
+    "california_water_action_plan.pdf": "https://resources.ca.gov/CNRALegacyFiles/docs/california_water_action_plan/Final_California_Water_Action_Plan.pdf",
+    "2019_caleap_enforcement_report.pdf": "https://calepa.ca.gov/wp-content/uploads/sites/6/2020/09/Enforcement-Report-2019.pdf",
+    "ej_program_update_2016.pdf": "https://calepa.ca.gov/wp-content/uploads/sites/6/2016/06/EnvJustice-Documents-EJ-Update-2016.pdf",
+    "refinery_safety_final_report_2014.pdf": "https://calepa.ca.gov/wp-content/uploads/sites/6/2016/10/Refinery-Task-Force-Final-Report.pdf",
+    "calenviroscreen2_report.pdf": "https://oehha.ca.gov/media/downloads/ej/report/ces20report.pdf",
+    "2013_arb_pm_report.pdf": "https://ww2.arb.ca.gov/sites/default/files/classic/research/apr/reports/l3006.pdf",
+    "leaf_blowers_legislature_report.pdf": "https://ww2.arb.ca.gov/sites/default/files/classic/research/apr/reports/l828.pdf",
+    "source_apportionment_final_report.pdf": "https://ww2.arb.ca.gov/sites/default/files/classic/research/apr/past/01-306.pdf"
+}
+
+def download_cadeq_documents() -> None:
+    """
+    Download CA DEQ documents from official sources.
+    
+    This function:
+    1. Creates the data directory if it doesn't exist
+    2. Downloads each PDF from the official CA DEQ URLs
+    3. Saves files locally with descriptive names
+    4. Provides progress feedback during download
+    
+    Raises:
+        requests.RequestException: If download fails
+        OSError: If file system operations fail
+    """
+    # Create data directory for storing PDF files
+    os.makedirs("data", exist_ok=True)
+    print(f"📁 Created/verified data directory: ./data") 
+    # Download each CA DEQ document
+    print(f"📥 Downloading {len(URLS)} CA DEQ documents...")
+    for filename, url in URLS.items():
+        try:
+            print(f"   ↓ {filename}")
+
+            # Download with timeout to prevent hanging
+            response = requests.get(url, timeout=90)
+            response.raise_for_status()  # Raise exception for bad status codes
+
+            # Save file to data directory
+            filepath = f"data/{filename}"
+            with open(filepath, "wb") as f:
+                f.write(response.content)
+                
+            # Show file size for verification
+            file_size = len(response.content) / (1024 * 1024)  # Convert to MB
+            print(f"     ✅ {file_size:.1f} MB downloaded")
+            
+        except requests.RequestException as e:
+            print(f"     ❌ Failed to download {filename}: {e}")
+            raise
+        except OSError as e:
+            print(f"     ❌ Failed to save {filename}: {e}")
+            raise
+    
+    print("\n🎉 All CA DEQ documents downloaded successfully!")
+    print("📂 Files available in: ./data")
+
+if __name__ == "__main__":
+    # Main execution when script is run directly
+    # Downloads all configured CA DEQ documents to the data directory
+    download_cadeq_documents() 

--- a/ingest.py
+++ b/ingest.py
@@ -1,7 +1,7 @@
 # =============================================================================
-# NASA Document Ingestion Pipeline
+# CA DEQ Document Ingestion Pipeline
 # =============================================================================
-# This script processes NASA PDF documents into a searchable vector database.
+# This script processes CA DEQ PDF documents into a searchable vector database.
 # It extracts text from PDFs, splits them into manageable chunks, and creates
 # embeddings using OpenAI's embedding model for semantic search capabilities.
 # =============================================================================
@@ -30,10 +30,10 @@ load_dotenv(override=True)
 # Find all PDF files in the data directory for processing
 # Uses pathlib.Path.glob() for cross-platform file discovery
 
-print("📄 Discovering PDF documents...")
+print("📄 Discovering CA DEQ PDF documents...")
 pdfs = Path("data").glob("*.pdf")
 pdf_list = list(pdfs)  # Convert to list to check count
-print(f"📋 Found {len(pdf_list)} PDF files to process")
+print(f"📋 Found {len(pdf_list)} CA DEQ PDF files to process")
 
 # =============================================================================
 # DOCUMENT LOADING
@@ -42,7 +42,7 @@ print(f"📋 Found {len(pdf_list)} PDF files to process")
 # PyPDFLoader handles the PDF parsing and text extraction
 
 docs = []
-print("📖 Loading and extracting text from PDFs...")
+print("📖 Loading and extracting text from CA DEQ PDFs...")
 
 for pdf in pdf_list:
     print(f"   📄 Processing: {pdf.name}")
@@ -55,7 +55,7 @@ for pdf in pdf_list:
     # Each page becomes a separate document with metadata
     docs.extend(loader.load())
 
-print(f"✅ Loaded {len(docs)} pages from {len(pdf_list)} PDF files")
+print(f"✅ Loaded {len(docs)} pages from {len(pdf_list)} CA DEQ PDF files")
 
 # =============================================================================
 # TEXT CHUNKING
@@ -63,7 +63,7 @@ print(f"✅ Loaded {len(docs)} pages from {len(pdf_list)} PDF files")
 # Split large documents into smaller, semantically meaningful chunks
 # This improves retrieval accuracy and fits within LLM context windows
 
-print("✂️  Splitting documents into searchable chunks...")
+print("✂️  Splitting CA DEQ documents into searchable chunks...")
 
 # Initialize the text splitter with optimized settings
 # RecursiveCharacterTextSplitter preserves semantic boundaries (paragraphs, sentences)
@@ -76,7 +76,7 @@ text_splitter = RecursiveCharacterTextSplitter(
 
 # Split all documents into chunks
 chunks = text_splitter.split_documents(docs)
-print(f"📋 Created {len(chunks)} searchable chunks")
+print(f"📋 Created {len(chunks)} searchable CA DEQ chunks")
 
 # =============================================================================
 # VECTOR DATABASE CREATION
@@ -84,7 +84,7 @@ print(f"📋 Created {len(chunks)} searchable chunks")
 # Create embeddings for each chunk and store in Chroma vector database
 # This enables semantic search based on meaning rather than just keywords
 
-print("🧠 Creating embeddings and building vector database...")
+print("🧠 Creating embeddings and building CA DEQ vector database...")
 print("   (This may take a few minutes for large document collections)")
 
 # Create vector database with OpenAI embeddings
@@ -97,7 +97,7 @@ vectordb = Chroma.from_documents(
     persist_directory="./chroma_db"                            # Local storage location
 )
 
-print(f"✅ Vector database created successfully!")
-print(f"📊 Database contains {len(chunks)} embedded document chunks")
+print(f"✅ CA DEQ vector database created successfully!")
+print(f"📊 Database contains {len(chunks)} embedded CA DEQ document chunks")
 print(f"💾 Database persisted to: ./chroma_db")
-print("\n🎉 Document ingestion complete! Ready for Q&A queries.")
+print("\n🎉 CA DEQ document ingestion complete! Ready for Q&A queries.")

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ User Input → Configuration Loading → Agent Creation → Tool Integration →
 from langchain_core.messages import HumanMessage
 from common import (
     ThinkingSpinner,     # UI component for loading animations
-    create_nasa_agent,   # Factory function for creating configured agents
+    create_cadeq_agent,   # Factory function for creating configured agents
     load_environment     # Configuration loading and validation
 )
 
@@ -49,8 +49,8 @@ def main():
     - Error isolation: Catches and handles errors without crashing
     - User experience: Provides clear feedback and status information
     """
-    print("🚀 NASA Document Q&A System")
-    print("Ask questions about NASA documents. Type 'quit', 'exit', or 'q' to stop.")
+    print("🌎 CA DEQ Document Q&A System")
+    print("Ask questions about California DEQ (CalEPA) documents. Type 'quit', 'exit', or 'q' to stop.")
     print("=" * 60)
     
     # CONFIGURATION PHASE
@@ -61,10 +61,10 @@ def main():
     
     # AGENT CREATION PHASE  
     # Create an AI agent with the appropriate tools based on configuration
-    # - Always includes NASA document search capability
+    # - Always includes CA DEQ document search capability
     # - Conditionally includes MCP filesystem tools if servers are available
     # - Uses environment-specified model (default: gpt-4.1)
-    agent = create_nasa_agent(
+    agent = create_cadeq_agent(
         include_mcp=agent_config["include_mcp"],  # MCP tools if servers configured
         model=agent_config["model"]               # AI model from environment
     )

--- a/module_design_specification.md
+++ b/module_design_specification.md
@@ -40,13 +40,12 @@ This document details the design and responsibilities of each module in the NASA
   - Exposes configuration via `AppConfig` class.
 - **Key Patterns:** Singleton, Factory, Validation.
 
-### 3.2 `common/nasa_search.py`
-- **Purpose:** NASA document search and RAG (Retrieval-Augmented Generation).
-- **Responsibilities:**
-  - Loads and manages the Chroma vector database.
-  - Embeds and retrieves document chunks.
-  - Synthesizes answers using LLMs.
-- **Key Patterns:** Singleton, Factory, Template Method, Lazy Loading.
+### 3.2 `common/cadeq_search.py`
+- **Purpose:** Implements the `CADEQDocumentSearch` class for vector search and RAG over CA DEQ/CalEPA studies.
+- **Key Functions:**
+  - `CADEQDocumentSearch`: Handles vector DB connection, semantic search, and LLM-based answer generation.
+  - `get_cadeq_search_tool`: Returns a LangChain tool for agent integration.
+  - `get_cadeq_db_info`: Returns metadata about the vector database.
 
 ### 3.3 `common/mcp_client.py`
 - **Purpose:** MCP (Model Context Protocol) integration for external tool access.
@@ -57,12 +56,10 @@ This document details the design and responsibilities of each module in the NASA
 - **Key Patterns:** Adapter, Singleton, Proxy, Factory.
 
 ### 3.4 `common/agent_factory.py`
-- **Purpose:** Factory for creating and configuring AI agents.
-- **Responsibilities:**
-  - Assembles agents with NASA search and optional MCP tools.
-  - Configures model, temperature, and system prompts.
-  - Handles tool integration and error isolation.
-- **Key Patterns:** Factory, Builder, Strategy, Template Method.
+- **Purpose:** Implements the `AgentFactory` for creating agents with CA DEQ and optional MCP tools.
+- **Key Functions:**
+  - `AgentFactory`: Handles agent creation, tool integration, and prompt generation.
+  - `create_cadeq_agent`: Factory function for main application.
 
 ### 3.5 `common/thinking_spinner.py`
 - **Purpose:** Terminal UI spinner for user feedback during processing.
@@ -81,37 +78,34 @@ This document details the design and responsibilities of each module in the NASA
 ## 4. Application Modules
 
 ### 4.1 `main.py`
-- **Role:** Presentation Layer.
-- **Responsibilities:**
-  - Loads configuration.
-  - Creates the agent.
-  - Runs the interactive Q&A loop.
-  - Handles user input and output.
-  - Provides error handling and user feedback.
+- **Purpose:** User interface for Q&A over CA DEQ documents.
+- **Key Functions:**
+  - Loads configuration and agent
+  - Handles user input and displays answers
 
 ### 4.2 `ingest.py`
-- **Role:** Data Layer.
-- **Responsibilities:**
-  - Loads PDF files from the `data/` directory.
-  - Splits documents into chunks.
-  - Embeds chunks and stores them in the Chroma vector DB.
+- **Purpose:** Ingests all CA DEQ PDFs, splits into chunks, and builds Chroma vector DB.
+- **Key Functions:**
+  - Loads all PDFs from `data/`
+  - Splits documents into chunks
+  - Embeds and stores in Chroma DB
 
-### 4.3 `fetch_nasa_data.py`
-- **Role:** Data Acquisition.
-- **Responsibilities:**
-  - Downloads official NASA PDFs into the `data/` directory.
+### 4.3 `fetch_cadeq_data.py`
+- **Purpose:** Downloads 10 CA DEQ/CalEPA studies and reports as PDFs for ingestion.
+- **Key Functions:**
+  - `download_cadeq_documents`: Downloads and saves all source PDFs to the `data/` directory.
 
 ### 4.4 `debug_embeddings.py`
-- **Role:** Diagnostics.
-- **Responsibilities:**
-  - Tests the embedding pipeline.
-  - Verifies OpenAI API connectivity and embedding quality.
+- **Purpose:** Test and debug scripts for embeddings and retrieval, using CA DEQ/environmental queries.
+- **Key Functions:**
+  - Test embedding pipeline and vector DB
+  - Run sample queries for retrieval validation
 
 ### 4.5 `test_retrieval.py`
-- **Role:** Testing.
-- **Responsibilities:**
-  - Runs sample queries against the vector DB.
-  - Validates retrieval and answer quality.
+- **Purpose:** Test and debug scripts for embeddings and retrieval, using CA DEQ/environmental queries.
+- **Key Functions:**
+  - Test embedding pipeline and vector DB
+  - Run sample queries for retrieval validation
 
 ### 4.6 `test_langchain_mcp.py`
 - **Role:** Integration Testing.
@@ -145,8 +139,8 @@ This document details the design and responsibilities of each module in the NASA
 ## 7. Extensibility
 
 - **Add new document types:** Extend `ingest.py` to support new formats.
-- **Custom prompts:** Update prompt templates in `common/nasa_search.py`.
-- **New tools/integrations:** Add to `common/agent_factory.py` and `common/mcp_client.py`.
+- **Custom prompts:** Update prompt templates in `common/cadeq_search.py`.
+- **New tools/integrations:** Add to `common/mcp_client.py`.
 - **Configuration:** Add new settings to `common/config.py`.
 - **Testing:** Add new test scripts or extend existing ones.
 
@@ -175,7 +169,7 @@ This document details the design and responsibilities of each module in the NASA
 | Presentation      | `main.py`, `common/thinking_spinner.py` | User interaction, feedback, UI                  |
 | Agent             | `common/agent_factory.py`        | Agent creation and configuration                 |
 | Integration       | `common/mcp_client.py`, `mcp_filesystem.py` | MCP tool integration, external access           |
-| Data              | `common/nasa_search.py`, `ingest.py`, `fetch_nasa_data.py` | Document ingestion, search, and retrieval       |
+| Data              | `common/cadeq_search.py`, `ingest.py`, `fetch_cadeq_data.py` | Document ingestion, search, and retrieval       |
 | Configuration     | `common/config.py`               | Environment and application configuration        |
 | Testing/Debugging | `debug_embeddings.py`, `test_retrieval.py`, `test_langchain_mcp.py` | Diagnostics and validation                      |
 

--- a/test_retrieval.py
+++ b/test_retrieval.py
@@ -17,10 +17,10 @@ def test_retrieval():
     )
     
     test_queries = [
-        'NASA risk management', 
-        'Artemis mission', 
-        'systems engineering', 
-        'technical requirements'
+        'CA DEQ risk management', 
+        'air quality monitoring', 
+        'environmental justice', 
+        'California water action'
     ]
     
     print('Testing retrieval with sample queries:')


### PR DESCRIPTION
…ystem

- All code, comments, and documentation updated from NASA to CA DEQ/CalEPA
- Document download logic now uses 10 CA DEQ/CalEPA studies/reports
- All user-facing prompts, help text, and test queries updated
- File and class/function names refactored (nasa → cadeq)
- SDS and MDS documentation updated for CA DEQ
- Generated by ChatGPT